### PR TITLE
Ticket 11 screen fix

### DIFF
--- a/cilantro_audit/constants.py
+++ b/cilantro_audit/constants.py
@@ -32,6 +32,7 @@ HOME_SCREEN = "HomeScreen"
 ADMIN_SCREEN = "AdminScreen"
 AUDITOR_SCREEN = "AuditorScreen"
 CREATE_AUDIT_TEMPLATE_PAGE = "CreateAuditTemplatePage"
+VIEW_AUDIT_TEMPLATES = "ViewAuditTemplates"
 
 # Colors
 RGB_RED = get_color_from_hex("#FF4500")

--- a/cilantro_audit/home_page.py
+++ b/cilantro_audit/home_page.py
@@ -6,9 +6,10 @@ from kivy.uix.screenmanager import Screen
 from kivy.uix.screenmanager import ScreenManager
 
 from cilantro_audit.auditor_page import AuditorPage
-from cilantro_audit.constants import KIVY_REQUIRED_VERSION, ADMIN_SCREEN, HOME_SCREEN, AUDITOR_SCREEN,\
-    CREATE_AUDIT_TEMPLATE_PAGE
+from cilantro_audit.constants import KIVY_REQUIRED_VERSION, ADMIN_SCREEN, HOME_SCREEN, AUDITOR_SCREEN, \
+    CREATE_AUDIT_TEMPLATE_PAGE, VIEW_AUDIT_TEMPLATES
 from cilantro_audit.create_audit_template_page import CreateAuditTemplatePage
+from view_audit_templates import ViewAuditTemplates
 
 kivy.require(KIVY_REQUIRED_VERSION)
 
@@ -43,6 +44,7 @@ class CilantroAudit(App):
         sm.add_widget(AdminPage(name=ADMIN_SCREEN))
         sm.add_widget(AuditorPage(name=AUDITOR_SCREEN))
         sm.add_widget(CreateAuditTemplatePage(name=CREATE_AUDIT_TEMPLATE_PAGE))
+        sm.add_widget(ViewAuditTemplates(name=VIEW_AUDIT_TEMPLATES))
 
         self.title = 'CilantroAudit'
         return sm

--- a/cilantro_audit/view_audit_templates.py
+++ b/cilantro_audit/view_audit_templates.py
@@ -1,5 +1,6 @@
 import kivy
 from kivy.app import App
+from kivy.properties import ObjectProperty
 from mongoengine import connect
 from kivy.uix.button import Button
 from kivy.uix.screenmanager import Screen
@@ -12,21 +13,31 @@ from cilantro_audit.audit_template import AuditTemplate
 # Required Version
 kivy.require(KIVY_REQUIRED_VERSION)
 
-
 Builder.load_file("./widgets/view_audit_templates.kv")
 
 
+# Will implement opening of an audit to fill out.
 class AuditButton(Button):
     pass
 
 
+# Handles the retrieval of audit templates for the auditor screens.
 class ViewAuditTemplates(Screen):
+    # Holds the list of titles retrieved from the database.
+    templates_list = ObjectProperty()
     connect(PROD_DB)
 
+    # Constructor utilizes the only method to retrieve audits for use in the associated .kv file.
+    def __init__(self, **kw):
+        super().__init__(**kw)
+        self.titles = []
+        self.get_audit_templates()
+
+    # Gets audit template titles for display in the page. Retrieves only title for faster retrieval time.
     def get_audit_templates(self):
         titles = list(map(lambda template: template.title, AuditTemplate.objects().only('title')))
         for title in titles:
-            self.ids["audits_list"].add_widget(AuditButton(text=title))
+            self.templates_list.add_widget(AuditButton(text=title))
 
 
 class TestApp(App):

--- a/cilantro_audit/view_audit_templates.py
+++ b/cilantro_audit/view_audit_templates.py
@@ -5,7 +5,7 @@ from kivy.uix.button import Button
 from kivy.uix.screenmanager import Screen
 from kivy.uix.screenmanager import ScreenManager
 
-from cilantro_audit.constants import KIVY_REQUIRED_VERSION
+from cilantro_audit.constants import KIVY_REQUIRED_VERSION, HOME_SCREEN, AUDITOR_SCREEN
 from cilantro_audit.constants import PROD_DB
 from cilantro_audit.home_page import HomePage
 from cilantro_audit.auditor_page import AuditorPage
@@ -44,8 +44,8 @@ class ViewAuditTemplates(App):
 
         # Add all associated pages to the root manager
         self.root.add_widget(root_page)
-        self.root.add_widget(HomePage(name="HomePage"))
-        self.root.add_widget(AuditorPage(name="AuditorPage"))
+        self.root.add_widget(HomePage(name=HOME_SCREEN))
+        self.root.add_widget(AuditorPage(name=AUDITOR_SCREEN))
 
         return self.root
 

--- a/cilantro_audit/view_audit_templates.py
+++ b/cilantro_audit/view_audit_templates.py
@@ -3,52 +3,36 @@ from kivy.app import App
 from mongoengine import connect
 from kivy.uix.button import Button
 from kivy.uix.screenmanager import Screen
-from kivy.uix.screenmanager import ScreenManager
+from kivy.lang import Builder
 
-from cilantro_audit.constants import KIVY_REQUIRED_VERSION, HOME_SCREEN, AUDITOR_SCREEN
+from cilantro_audit.constants import KIVY_REQUIRED_VERSION
 from cilantro_audit.constants import PROD_DB
-from cilantro_audit.home_page import HomePage
-from cilantro_audit.auditor_page import AuditorPage
 from cilantro_audit.audit_template import AuditTemplate
 
 # Required Version
 kivy.require(KIVY_REQUIRED_VERSION)
 
-# Default Database Connection
-connect(PROD_DB)
 
-
-class Manager(ScreenManager):
-    pass
-
-
-class ThisPage(Screen):
-    def get_audit_templates(self):
-        titles = list(map(lambda template: template.title, AuditTemplate.objects().only('title')))
-        for title in titles:
-            self.ids["audits_list"].add_widget(AuditButton(text=title))
+Builder.load_file("./widgets/view_audit_templates.kv")
 
 
 class AuditButton(Button):
     pass
 
 
-class ViewAuditTemplates(App):
+class ViewAuditTemplates(Screen):
+    connect(PROD_DB)
+
+    def get_audit_templates(self):
+        titles = list(map(lambda template: template.title, AuditTemplate.objects().only('title')))
+        for title in titles:
+            self.ids["audits_list"].add_widget(AuditButton(text=title))
+
+
+class TestApp(App):
     def build(self):
-        self.title = 'CilantroAudit - Audit Templates'
-        self.load_kv('./widgets/view_audit_templates.kv')
-
-        # Initialize this page and set the data
-        root_page = ThisPage()
-        root_page.get_audit_templates()
-
-        # Add all associated pages to the root manager
-        self.root.add_widget(root_page)
-        self.root.add_widget(HomePage(name=HOME_SCREEN))
-        self.root.add_widget(AuditorPage(name=AUDITOR_SCREEN))
-
-        return self.root
+        return ViewAuditTemplates()
 
 
 if __name__ == '__main__':
-    ViewAuditTemplates().run()
+    TestApp.run()

--- a/cilantro_audit/widgets/auditor_page.kv
+++ b/cilantro_audit/widgets/auditor_page.kv
@@ -10,6 +10,7 @@
                 size: 250, 100
                 size_hint: None, None
                 pos_hint: {"center_x": -0.8, "center_y": 0.8}
+                on_press: root.manager.current = 'ViewAuditTemplates'
 
             Button:
                 text: "View Submitted Audits"
@@ -17,6 +18,7 @@
                 size: 250, 100
                 size_hint: None, None
                 pos_hint: {"center_x": 1.8, "center_y": 0.8}
+                
 
             Button:
                 text: "Return to Homepage"

--- a/cilantro_audit/widgets/view_audit_templates.kv
+++ b/cilantro_audit/widgets/view_audit_templates.kv
@@ -27,7 +27,7 @@ Manager:
                 text: 'Back'
                 size_hint: 0.3, 1.0
                 on_release:
-                    app.root.current = 'AuditorPage'
+                    app.root.current = 'AuditorScreen'
                     app.root.transition.duration = 0.3
                     app.root.transition.direction = 'right'
 
@@ -95,7 +95,7 @@ Manager:
             Button:
                 text: 'Return Home'
                 on_release:
-                    app.root.current = 'HomePage'
+                    app.root.current = 'HomeScreen'
                     app.root.transition.duration = 0.3
                     app.root.transition.direction = 'down'
 

--- a/cilantro_audit/widgets/view_audit_templates.kv
+++ b/cilantro_audit/widgets/view_audit_templates.kv
@@ -1,11 +1,8 @@
 #:kivy 1.11.1
 
 
-Manager:
-
-
-<ThisPage>:
-    name: 'this_page'
+<ViewAuditTemplates>:
+    name: 'ViewAuditTemplates'
 
     BoxLayout:
         orientation: 'vertical'
@@ -105,6 +102,6 @@ Manager:
 
     size_hint_y: None
     on_release:
-        app.root.current = 'this_page'
+        app.root.current = 'ViewAuditTemplates'
         app.root.transition.duration = 0.3
         app.root.transition.direction = 'right'

--- a/cilantro_audit/widgets/view_audit_templates.kv
+++ b/cilantro_audit/widgets/view_audit_templates.kv
@@ -3,6 +3,7 @@
 
 <ViewAuditTemplates>:
     name: 'ViewAuditTemplates'
+    templates_list: templates_list
 
     BoxLayout:
         orientation: 'vertical'
@@ -29,7 +30,7 @@
                     app.root.transition.direction = 'right'
 
             Label:
-                text: 'Audit Templates'
+                text: 'Available Audits'
                 color: 1.0, 1.0, 1.0, 1
 
             Button:
@@ -65,7 +66,7 @@
                     name: 'middle-col'
 
                     StackLayout:
-                        id: audits_list
+                        id: templates_list
                         height: self.minimum_height
                         size_hint_y: None
 


### PR DESCRIPTION
Solved circular imports by removing the instance of `ScreenManager` created in `view_audit_templates`. Doing this necessitated the porting of our existing `Screen` structure into this page, including:

- Removing `ViewAuditTemplatesScreen` class, which previously extended `Screen`.
- Making the `ViewAuditTemplates` class extend `Screen`.
- Moving the `get_audit_templates` method into `ViewAuditTemplates`, and running it as part of `__init__`.
- Bringing data into the .kv file via an ObjectProperty, as was done in the `CreateAuditTemplatePage`.
