### PR TITLE
Ticket-80: Open an audit from the template viewer to complete

### DIFF
--- a/cilantro_audit/answer_module.py
+++ b/cilantro_audit/answer_module.py
@@ -1,0 +1,68 @@
+from kivy.app import App
+from kivy.lang import Builder
+from kivy.properties import ObjectProperty, StringProperty
+from kivy.uix.checkbox import CheckBox
+from kivy.uix.floatlayout import FloatLayout
+from mongoengine import connect
+
+from cilantro_audit.completed_audit import Response
+from cilantro_audit.constants import RGB_GREEN, RGB_GREY_LIGHT, COMMENT_MAX_LENGTH
+
+Builder.load_file("./widgets/answer_module.kv")
+
+
+class AnswerModule(FloatLayout):
+    """ The widget an auditor sees,
+    gets text from the auditTemplate, gets yes/no/other from auditor via checkbox
+    """
+    question_label = ObjectProperty()
+    question_text = StringProperty()
+    yes_box = ObjectProperty()
+    no_box = ObjectProperty()
+    other_box = ObjectProperty()
+    other_comments = ObjectProperty()
+
+    question = None
+    response = None
+
+    def yes_box_press(self):
+        self.response = Response.yes()
+        self.yes_box.background_color = RGB_GREEN
+        self.no_box.background_color = RGB_GREY_LIGHT
+        self.other_box.background_color = RGB_GREY_LIGHT
+
+    def no_box_press(self):
+        self.response = Response.no()
+        self.yes_box.background_color = RGB_GREY_LIGHT
+        self.no_box.background_color = RGB_GREEN
+        self.other_box.background_color = RGB_GREY_LIGHT
+
+    def other_box_press(self):
+        self.response = Response.other()
+        self.yes_box.background_color = RGB_GREY_LIGHT
+        self.no_box.background_color = RGB_GREY_LIGHT
+        self.other_box.background_color = RGB_GREEN
+
+    def other_has_comments(self):
+        if self.response is Response.other():
+            if self.other_comments.text:
+                return True
+            else:
+                return False
+        else:
+            return True
+
+    # Verify the length of the comment does not exceed database defined limit.
+    def verify_comment_length(self):
+        if len(self.other_comments.text) > COMMENT_MAX_LENGTH:
+            self.other_comments.text = self.other_comments.text[0:COMMENT_MAX_LENGTH]
+        print(self.other_comments.text)
+
+
+class TestApp(App):
+    def build(self):
+        return AnswerModule()
+
+
+if __name__ == "__main__":
+    TestApp().run()

--- a/cilantro_audit/answer_module.py
+++ b/cilantro_audit/answer_module.py
@@ -44,7 +44,7 @@ class AnswerModule(FloatLayout):
         self.other_box.background_color = RGB_GREEN
 
     def other_has_comments(self):
-        if self.response is Response.other():
+        if self.response.response is Response.other().response:
             if self.other_comments.text:
                 return True
             else:

--- a/cilantro_audit/answer_module.py
+++ b/cilantro_audit/answer_module.py
@@ -52,12 +52,6 @@ class AnswerModule(FloatLayout):
         else:
             return True
 
-    # Verify the length of the comment does not exceed database defined limit.
-    def verify_comment_length(self):
-        if len(self.other_comments.text) > COMMENT_MAX_LENGTH:
-            self.other_comments.text = self.other_comments.text[0:COMMENT_MAX_LENGTH]
-        print(self.other_comments.text)
-
 
 class TestApp(App):
     def build(self):

--- a/cilantro_audit/constants.py
+++ b/cilantro_audit/constants.py
@@ -47,3 +47,4 @@ VIEW_AUDIT_TEMPLATES = "ViewAuditTemplates"
 RGB_RED = get_color_from_hex("#FF4500")
 RGB_GREEN = get_color_from_hex("#00FA9A")
 RGB_YELLOW = get_color_from_hex("#FFFF00")
+RGB_GREY_LIGHT = get_color_from_hex("D3D3D3")

--- a/cilantro_audit/constants.py
+++ b/cilantro_audit/constants.py
@@ -41,6 +41,7 @@ CREATE_AUDIT_PAGE = "CreateAuditPage"
 COMPLETED_AUDITS_LIST_PAGE = "CompletedAuditsListPage"
 AUDITOR_COMPLETED_AUDITS_LIST_PAGE = "AuditorCompletedAuditsListPage"
 CREATE_AUDIT_TEMPLATE_PAGE = "CreateAuditTemplatePage"
+CREATE_COMPLETED_AUDIT_PAGE = "CreateCompletedAuditPage"
 VIEW_AUDIT_TEMPLATES = "ViewAuditTemplates"
 
 # Colors

--- a/cilantro_audit/create_audit_template_page.py
+++ b/cilantro_audit/create_audit_template_page.py
@@ -24,7 +24,7 @@ class ConfirmationPop(Popup):
 
     def return_admin_page(self):
         self.dismiss()
-        self.manager.current = VIEW_AUDIT_TEMPLATES
+        self.manager.current = ADMIN_SCREEN
 
 
 class ErrorPop(Popup):

--- a/cilantro_audit/create_audit_template_page.py
+++ b/cilantro_audit/create_audit_template_page.py
@@ -8,7 +8,8 @@ from kivy.uix.screenmanager import Screen
 from mongoengine import connect
 
 from cilantro_audit.audit_template import AuditTemplateBuilder, Question, AuditTemplate
-from cilantro_audit.constants import KIVY_REQUIRED_VERSION, PROD_DB, ADMIN_SCREEN, TITLE_MAX_LENGTH, TEXT_MAX_LENGTH
+from cilantro_audit.constants import KIVY_REQUIRED_VERSION, PROD_DB, ADMIN_SCREEN, TITLE_MAX_LENGTH, TEXT_MAX_LENGTH, \
+    VIEW_AUDIT_TEMPLATES
 from cilantro_audit.question_module import QuestionModule
 
 kivy.require(KIVY_REQUIRED_VERSION)
@@ -23,7 +24,7 @@ class ConfirmationPop(Popup):
 
     def return_admin_page(self):
         self.dismiss()
-        self.manager.current = ADMIN_SCREEN
+        self.manager.current = VIEW_AUDIT_TEMPLATES
 
 
 class ErrorPop(Popup):

--- a/cilantro_audit/create_completed_audit_page.py
+++ b/cilantro_audit/create_completed_audit_page.py
@@ -68,6 +68,8 @@ class CreateCompletedAuditPage(Screen, FloatLayout):
         # the content’s bottom side will touch the bottom side of the ScrollView. If 1, the content’s top side will
         # touch the top side.
         self.scrolling_panel.scroll_y = 1
+        # Reset the auditor name
+        self.auditor_name.text = ''
 
     # Return the associated severity with question's response
     def question_severity(self, question):

--- a/cilantro_audit/create_completed_audit_page.py
+++ b/cilantro_audit/create_completed_audit_page.py
@@ -33,11 +33,10 @@ class CreateCompletedAuditPage(Screen, FloatLayout):
     def __init__(self, **kw):
         super().__init__(**kw)
         self.questions = []
-        self.populate_audit()
 
     # put all questions on the screen for the auditor to respond to
-    def populate_audit(self):
-        target = "Bathroom #1"
+    def populate_audit(self, audit_name):
+        target = audit_name
         try:
             template = AuditTemplate.objects().filter(title=target).first()  # for now, while there can be duplicates
         except AttributeError:

--- a/cilantro_audit/create_completed_audit_page.py
+++ b/cilantro_audit/create_completed_audit_page.py
@@ -14,7 +14,6 @@ from cilantro_audit.create_audit_template_page import ConfirmationPop, ErrorPop
 
 kivy.require(KIVY_REQUIRED_VERSION)
 
-
 # Loads in the .kv file which contains the CreateCompletedAuditPage layout.
 Builder.load_file("./widgets/create_completed_audit_page.kv")
 

--- a/cilantro_audit/create_completed_audit_page.py
+++ b/cilantro_audit/create_completed_audit_page.py
@@ -3,12 +3,13 @@ from kivy.app import App
 from kivy.lang import Builder
 from kivy.properties import ObjectProperty, StringProperty
 from kivy.uix.floatlayout import FloatLayout
+from kivy.uix.popup import Popup
 from kivy.uix.screenmanager import Screen
 from mongoengine import connect
 
 from cilantro_audit.audit_template import AuditTemplate
 from cilantro_audit.completed_audit import CompletedAuditBuilder, Answer, Response
-from cilantro_audit.constants import KIVY_REQUIRED_VERSION, PROD_DB
+from cilantro_audit.constants import KIVY_REQUIRED_VERSION, PROD_DB, VIEW_AUDIT_TEMPLATES
 from cilantro_audit.answer_module import AnswerModule
 from cilantro_audit.create_audit_template_page import ConfirmationPop, ErrorPop
 
@@ -16,6 +17,15 @@ kivy.require(KIVY_REQUIRED_VERSION)
 
 # Loads in the .kv file which contains the CreateCompletedAuditPage layout.
 Builder.load_file("./widgets/create_completed_audit_page.kv")
+
+
+# The popup used for both the back and submit buttons
+class ConfirmationPop(Popup):
+    yes = ObjectProperty(None)
+
+    def return_admin_page(self):
+        self.dismiss()
+        self.manager.current = VIEW_AUDIT_TEMPLATES
 
 
 class CreateCompletedAuditPage(Screen, FloatLayout):
@@ -27,6 +37,8 @@ class CreateCompletedAuditPage(Screen, FloatLayout):
     audit_title = StringProperty()
     # The auditor's name that is conducting the audit.
     auditor_name = ObjectProperty()
+    # The scrolling panel for view management
+    scrolling_panel = ObjectProperty()
 
     connect(PROD_DB)
 
@@ -51,6 +63,11 @@ class CreateCompletedAuditPage(Screen, FloatLayout):
             a_temp.question_text = question.text
             self.stack_list.add_widget(a_temp)
             self.questions.append(a_temp)
+
+        # https://kivy.org/doc/stable/api-kivy.uix.scrollview.html Y scrolling value, between 0 and 1. If 0,
+        # the content’s bottom side will touch the bottom side of the ScrollView. If 1, the content’s top side will
+        # touch the top side.
+        self.scrolling_panel.scroll_y = 1
 
     # Return the associated severity with question's response
     def question_severity(self, question):

--- a/cilantro_audit/create_completed_audit_page.py
+++ b/cilantro_audit/create_completed_audit_page.py
@@ -67,8 +67,11 @@ class CreateCompletedAuditPage(Screen, FloatLayout):
         # The object returned from the .kv is a TextField, with a member text
         completed_audit.with_auditor(self.auditor_name.text)
         for a in self.questions:
-            temp_answer = Answer(text=a.question.text, severity=self.question_severity(a), response=a.response,
-                                 comment=a.other_comments.text)
+            if a.other_comments.text:
+                temp_answer = Answer(text=a.question.text, severity=self.question_severity(a), response=a.response,
+                                     comment=a.other_comments.text)
+            else:
+                temp_answer = Answer(text=a.question.text, severity=self.question_severity(a), response=a.response)
             completed_audit.with_answer(temp_answer)
 
         completed_audit.build().save()
@@ -113,7 +116,9 @@ class CreateCompletedAuditPage(Screen, FloatLayout):
                 error_message = "Answers with 'Other' must have comments."
                 break
 
-        # will need an auditor name check when that is implemented
+        if not self.auditor_name.text:
+            error_message = "Please enter your name."
+
         return error_message
 
 

--- a/cilantro_audit/create_completed_audit_page.py
+++ b/cilantro_audit/create_completed_audit_page.py
@@ -1,0 +1,128 @@
+import kivy
+from kivy.app import App
+from kivy.lang import Builder
+from kivy.properties import ObjectProperty, StringProperty
+from kivy.uix.floatlayout import FloatLayout
+from kivy.uix.screenmanager import Screen
+from mongoengine import connect
+
+from cilantro_audit.audit_template import AuditTemplate
+from cilantro_audit.completed_audit import CompletedAuditBuilder, Answer, Response
+from cilantro_audit.constants import KIVY_REQUIRED_VERSION, PROD_DB
+from cilantro_audit.answer_module import AnswerModule
+from cilantro_audit.create_audit_template_page import ConfirmationPop, ErrorPop
+
+kivy.require(KIVY_REQUIRED_VERSION)
+
+
+# Loads in the .kv file which contains the CreateCompletedAuditPage layout.
+Builder.load_file("./widgets/create_completed_audit_page.kv")
+
+
+class CreateCompletedAuditPage(Screen, FloatLayout):
+    # The id for the StackLayout, Used to add questions to the layout.
+    stack_list = ObjectProperty()
+    # the actual label holding the audit title
+    title_label = ObjectProperty()
+    # The id for the title section of the audit.
+    audit_title = StringProperty()
+    # The auditor's name that is conducting the audit.
+    auditor_name = ObjectProperty()
+
+    connect(PROD_DB)
+
+    def __init__(self, **kw):
+        super().__init__(**kw)
+        self.questions = []
+        self.populate_audit()
+
+    # put all questions on the screen for the auditor to respond to
+    def populate_audit(self):
+        target = "Bathroom #1"
+        try:
+            template = AuditTemplate.objects().filter(title=target).first()  # for now, while there can be duplicates
+        except AttributeError:
+            # TO DO - SOMETHING
+            pass
+
+        self.audit_title = template.title
+        for question in template.questions:
+            self.stack_list.height += 200
+            a_temp = AnswerModule()
+            a_temp.question = question
+            a_temp.question_text = question.text
+            self.stack_list.add_widget(a_temp)
+            self.questions.append(a_temp)
+
+    # Return the associated severity with question's response
+    def question_severity(self, question):
+        if question.response == Response.yes():
+            return question.question.yes
+        elif question.response == Response.no():
+            return question.question.no
+        return question.question.other
+
+    # Function called after user selects yes on the confirmation popup
+    def submit_audit(self, callback):
+        completed_audit = CompletedAuditBuilder()
+        completed_audit.with_title(self.audit_title)
+        # The object returned from the .kv is a TextField, with a member text
+        completed_audit.with_auditor(self.auditor_name.text)
+        for a in self.questions:
+            temp_answer = Answer(text=a.question.text, severity=self.question_severity(a), response=a.response,
+                                 comment=a.other_comments.text)
+            completed_audit.with_answer(temp_answer)
+
+        completed_audit.build().save()
+
+    def submit_audit_pop(self, manager):
+        error_message = self.check_audit()
+        if error_message != "":
+            show = ErrorPop()
+            show.error_message.text = error_message
+        else:
+            show = ConfirmationPop()
+            show.yes.bind(on_press=self.clear_page)
+            show.yes.bind(on_press=self.submit_audit)
+        show.manager = manager
+        show.open()
+
+    # On press method for the back button
+    def back(self, manager):
+        show = ConfirmationPop()
+        show.yes.bind(on_press=self.clear_page)
+        show.manager = manager
+        show.open()
+
+    # Empties stack list and question list, should enable leaving early without a problem...
+    def clear_page(self, callback):
+        self.audit_title = ""
+        for question in self.questions:
+            self.stack_list.remove_widget(question)
+            self.stack_list.height -= 200
+        self.questions.clear()
+
+    # Ensures that the completedAudit has everything filled out before trying to .save() it
+    def check_audit(self):
+        error_message = ""
+        for question in self.questions:
+            # Check if all questions are answered
+            if question.response is None:
+                error_message = "Must respond to all questions."
+                break  # like this for now because there are changes to be made still
+            # Check if 'other' responses have comments.
+            if question.other_has_comments() is False:
+                error_message = "Answers with 'Other' must have comments."
+                break
+
+        # will need an auditor name check when that is implemented
+        return error_message
+
+
+class TestApp(App):
+    def build(self):
+        return CreateCompletedAuditPage()
+
+
+if __name__ == "__main__":
+    TestApp().run()

--- a/cilantro_audit/generate_demo_data.py
+++ b/cilantro_audit/generate_demo_data.py
@@ -98,8 +98,10 @@ RESPONSES = [
     Response.other(),
 ]
 
+
 def random_title():
     return random.choice(TITLES)
+
 
 def random_question():
     return Question(
@@ -108,6 +110,7 @@ def random_question():
         no=random.choice(SEVERITIES),
         other=random.choice(SEVERITIES),
     )
+
 
 def random_answer_from_question(question):
     text = question.text
@@ -125,12 +128,12 @@ def random_answer_from_question(question):
             response=response,
         )
     elif Response.other() == response:
-            return Answer(
-                text=question.text,
-                severity=question.yes,
-                response=response,
-                comment=random.choice(COMMENTS),
-            )
+        return Answer(
+            text=question.text,
+            severity=question.yes,
+            response=response,
+            comment=random.choice(COMMENTS),
+        )
 
 
 if __name__ == '__main__':

--- a/cilantro_audit/home_page.py
+++ b/cilantro_audit/home_page.py
@@ -13,7 +13,9 @@ from cilantro_audit.auditor_completed_audits_list_page import AuditorCompletedAu
 from cilantro_audit.view_audit_templates import ViewAuditTemplates
 
 from cilantro_audit.constants import KIVY_REQUIRED_VERSION, ADMIN_SCREEN, HOME_SCREEN, AUDITOR_SCREEN, \
-    CREATE_AUDIT_TEMPLATE_PAGE, COMPLETED_AUDITS_LIST_PAGE, AUDITOR_COMPLETED_AUDITS_LIST_PAGE, VIEW_AUDIT_TEMPLATES
+    CREATE_AUDIT_TEMPLATE_PAGE, COMPLETED_AUDITS_LIST_PAGE, AUDITOR_COMPLETED_AUDITS_LIST_PAGE, VIEW_AUDIT_TEMPLATES, \
+    CREATE_COMPLETED_AUDIT_PAGE
+from create_completed_audit_page import CreateCompletedAuditPage
 
 kivy.require(KIVY_REQUIRED_VERSION)
 
@@ -25,10 +27,6 @@ sm = ScreenManager()
 
 
 class HomePage(Screen):
-    pass
-
-
-class AdminPage(Screen):
     pass
 
 
@@ -51,6 +49,7 @@ class CilantroAudit(App):
         sm.add_widget(CompletedAuditsListPage(name=COMPLETED_AUDITS_LIST_PAGE))
         sm.add_widget(AuditorCompletedAuditsListPage(name=AUDITOR_COMPLETED_AUDITS_LIST_PAGE))
         sm.add_widget(ViewAuditTemplates(name=VIEW_AUDIT_TEMPLATES))
+        sm.add_widget(CreateCompletedAuditPage(name=CREATE_COMPLETED_AUDIT_PAGE))
 
         self.title = 'CilantroAudit'
         return sm

--- a/cilantro_audit/view_audit_templates.py
+++ b/cilantro_audit/view_audit_templates.py
@@ -16,7 +16,6 @@ kivy.require(KIVY_REQUIRED_VERSION)
 Builder.load_file("./widgets/view_audit_templates.kv")
 
 
-# Will implement opening of an audit to fill out.
 class AuditButton(Button):
     def __init__(self, **kwargs):
         super().__init__()

--- a/cilantro_audit/view_audit_templates.py
+++ b/cilantro_audit/view_audit_templates.py
@@ -25,7 +25,7 @@ class AuditButton(Button):
 
     def on_press(self, *args):
         super(AuditButton, self).on_press(*args)
-        self.screen_manager.get_screen(CREATE_COMPLETED_AUDIT_PAGE).populate_audit()
+        self.screen_manager.get_screen(CREATE_COMPLETED_AUDIT_PAGE).populate_audit(self.text)
         self.screen_manager.current = CREATE_COMPLETED_AUDIT_PAGE
 
 

--- a/cilantro_audit/view_audit_templates.py
+++ b/cilantro_audit/view_audit_templates.py
@@ -18,19 +18,14 @@ Builder.load_file("./widgets/view_audit_templates.kv")
 
 # Will implement opening of an audit to fill out.
 class AuditButton(Button):
-    pass
-
-
-class ScreenButton(Button):
     def __init__(self, **kwargs):
         super().__init__()
         self.screen_manager = kwargs['screen_manager']
         self.text = kwargs['text']
-        self.size_hint_y = 0
-        self.height = 300
 
     def on_press(self, *args):
-        super(ScreenButton, self).on_press(*args)
+        super(AuditButton, self).on_press(*args)
+        self.screen_manager.get_screen(CREATE_COMPLETED_AUDIT_PAGE).populate_audit()
         self.screen_manager.current = CREATE_COMPLETED_AUDIT_PAGE
 
 
@@ -52,13 +47,7 @@ class ViewAuditTemplates(Screen):
 
         titles = list(map(lambda template: template.title, AuditTemplate.objects().only('title')))
         for title in titles:
-            test = ScreenButton(text=title, screen_manager=self.screen_manager)
-            # self.templates_list.add_widget(AuditButton(text=title))
-            self.templates_list.add_widget(test)
-
-    # def load_page(self, audit_button):
-    #     print(self.screen_manager.children)
-    #     self.screen_manager.current = CREATE_COMPLETED_AUDIT_PAGE
+            self.templates_list.add_widget(AuditButton(text=title, screen_manager=self.screen_manager))
 
 
 class TestApp(App):

--- a/cilantro_audit/view_audit_templates.py
+++ b/cilantro_audit/view_audit_templates.py
@@ -42,6 +42,7 @@ class ViewAuditTemplates(Screen):
 
     # Gets audit template titles for display in the page. Retrieves only title for faster retrieval time.
     def get_audit_templates(self, screen_manager):
+        self.templates_list.clear_widgets()
         self.screen_manager = screen_manager
 
         titles = list(map(lambda template: template.title, AuditTemplate.objects().only('title')))

--- a/cilantro_audit/view_audit_templates.py
+++ b/cilantro_audit/view_audit_templates.py
@@ -6,7 +6,7 @@ from kivy.uix.button import Button
 from kivy.uix.screenmanager import Screen
 from kivy.lang import Builder
 
-from cilantro_audit.constants import KIVY_REQUIRED_VERSION
+from cilantro_audit.constants import KIVY_REQUIRED_VERSION, CREATE_COMPLETED_AUDIT_PAGE
 from cilantro_audit.constants import PROD_DB
 from cilantro_audit.audit_template import AuditTemplate
 
@@ -21,6 +21,19 @@ class AuditButton(Button):
     pass
 
 
+class ScreenButton(Button):
+    def __init__(self, **kwargs):
+        super().__init__()
+        self.screen_manager = kwargs['screen_manager']
+        self.text = kwargs['text']
+        self.size_hint_y = 0
+        self.height = 300
+
+    def on_press(self, *args):
+        super(ScreenButton, self).on_press(*args)
+        self.screen_manager.current = CREATE_COMPLETED_AUDIT_PAGE
+
+
 # Handles the retrieval of audit templates for the auditor screens.
 class ViewAuditTemplates(Screen):
     # Holds the list of titles retrieved from the database.
@@ -31,13 +44,21 @@ class ViewAuditTemplates(Screen):
     def __init__(self, **kw):
         super().__init__(**kw)
         self.titles = []
-        self.get_audit_templates()
+        # self.get_audit_templates()
 
     # Gets audit template titles for display in the page. Retrieves only title for faster retrieval time.
-    def get_audit_templates(self):
+    def get_audit_templates(self, screen_manager):
+        self.screen_manager = screen_manager
+
         titles = list(map(lambda template: template.title, AuditTemplate.objects().only('title')))
         for title in titles:
-            self.templates_list.add_widget(AuditButton(text=title))
+            test = ScreenButton(text=title, screen_manager=self.screen_manager)
+            # self.templates_list.add_widget(AuditButton(text=title))
+            self.templates_list.add_widget(test)
+
+    # def load_page(self, audit_button):
+    #     print(self.screen_manager.children)
+    #     self.screen_manager.current = CREATE_COMPLETED_AUDIT_PAGE
 
 
 class TestApp(App):

--- a/cilantro_audit/widgets/answer_module.kv
+++ b/cilantro_audit/widgets/answer_module.kv
@@ -1,0 +1,88 @@
+<AnswerModule>:
+
+#:import GREY_LIGHT cilantro_audit.constants.RGB_GREY_LIGHT
+#:import COMMENT_MAX_LENGTH cilantro_audit.constants.COMMENT_MAX_LENGTH
+#:import COMMENT_MIN_LENGTH cilantro_audit.constants.COMMENT_MIN_LENGTH
+
+    question_label: question_label
+    yes_box: yes_box
+    no_box: no_box
+    other_box: other_box
+    other_comments: other_comments
+
+    size_hint: 1, None
+    height: 200
+
+    # Question text
+    Label:
+        id: question_label
+        text: root.question_text
+        color: 1, 1, 1, 1
+        size_hint: None, None
+        pos_hint: {"top": 0.9, "center_x": 0.5}
+        text_size: root.width-100, None
+
+    # Yes button
+    Button:
+        id: yes_box
+        background_color: GREY_LIGHT
+        size: 60, 60
+        size_hint: None, None
+        pos_hint: {"top": 0.5, "center_x": 0.1}
+        on_press: root.yes_box_press()
+
+    # Yes label
+    Label:
+        text: "Yes"
+        size_hint: None, None
+        pos_hint: {"top": 0.6, "center_x": 0.1}
+
+    # No button
+    Button:
+        id: no_box
+        background_color: GREY_LIGHT
+        size: 60, 60
+        size_hint: None, None
+        pos_hint: {"top": 0.5, "center_x": 0.24}
+        on_press: root.no_box_press()
+
+    # No label
+    Label:
+        text: "No"
+        size_hint: None, None
+        pos_hint: {"top": 0.6, "center_x": 0.24}
+
+    # Other button
+    Button:
+        id: other_box
+        background_color: GREY_LIGHT
+        size: 60, 60
+        size_hint: None, None
+        pos_hint: {"top": 0.5, "center_x": 0.37}
+        on_press: root.other_box_press()
+
+    # Other label
+    Label:
+        text: "Other"
+        size_hint: None, None
+        pos_hint: {"top": 0.6, "center_x": 0.37}
+
+    # Comments label
+    Label:
+        text: "Comments"
+        size_hint: None, None
+        pos_hint: {"top": 0.8, "center_x": 0.7}
+
+    # Comments input
+    TextInput:
+        id: other_comments
+        size_hint: None, None
+        pos_hint: {"top": 0.48, "center_x":0.7}
+        size: 250, 50
+        # Limits comment length to database defined max length. From
+        # https://stackoverflow.com/questions/25296508/set-the-width-property-for-textinput
+        # On every input we check filter the text to a substring that is at most
+        # COMMENT_MAX_LENGTH long.
+        input_filter: lambda text, from_undo: text[:COMMENT_MAX_LENGTH - len(self.text)]
+        hint_text: "Comment is required if 'Other' is checked"
+

--- a/cilantro_audit/widgets/auditor_page.kv
+++ b/cilantro_audit/widgets/auditor_page.kv
@@ -1,5 +1,7 @@
-
 <AuditorPage>:
+
+#:import AUDITOR_PAGE cilantro_audit.constants.VIEW_AUDIT_TEMPLATES
+
     FloatLayout:
         FloatLayout:
             pos_hint: {"center_x": 0.5, "center_y": 0.6}
@@ -12,6 +14,7 @@
                 size_hint: None, None
                 pos_hint: {"center_x": -0.8, "center_y": 0.8}
                 on_release:
+                    root.manager.get_screen(AUDITOR_PAGE).get_audit_templates(root.manager)
                     root.manager.current = 'ViewAuditTemplates'
                     root.manager.transition.duration = 0.3
                     root.manager.transition.direction = 'left'

--- a/cilantro_audit/widgets/completed_audits_list_page.kv
+++ b/cilantro_audit/widgets/completed_audits_list_page.kv
@@ -2,7 +2,7 @@
 <CompletedAuditsListPage>:
 
 #:import ADMIN_SCREEN cilantro_audit.constants.ADMIN_SCREEN
-#:import THIS_PAGE cilantro_audit.constants.COMPLETED_AUDITS_LIST_PAGE
+#:import COMPLETED_AUDITS_LIST_PAGE cilantro_audit.constants.COMPLETED_AUDITS_LIST_PAGE
 
     date_col: date_col
     title_col: title_col
@@ -32,25 +32,25 @@
                     id: title_header
                     text: 'Title'
                     spacing: 10
-                    on_press: root.manager.get_screen(THIS_PAGE).sort_by_title()
+                    on_press: root.manager.get_screen(COMPLETED_AUDITS_LIST_PAGE).sort_by_title()
 
                 Button:
                     id: date_header
                     text: 'Date'
                     spacing: 10
-                    on_press: root.manager.get_screen(THIS_PAGE).sort_by_date()
+                    on_press: root.manager.get_screen(COMPLETED_AUDITS_LIST_PAGE).sort_by_date()
 
                 Button:
                     id: auditor_header
                     text: 'Auditor'
                     spacing: 10
-                    on_press: root.manager.get_screen(THIS_PAGE).sort_by_auditor()
+                    on_press: root.manager.get_screen(COMPLETED_AUDITS_LIST_PAGE).sort_by_auditor()
 
                 Button:
                     id: auditor_header
                     text: 'Severity'
                     spacing: 10
-                    on_press: root.manager.get_screen(THIS_PAGE).sort_by_severity()
+                    on_press: root.manager.get_screen(COMPLETED_AUDITS_LIST_PAGE).sort_by_severity()
 
             ScrollView:
                 id: scrollable_list
@@ -95,4 +95,4 @@
                 text: 'Refresh List'
                 size_hint_y: None
                 size: 400, 50
-                on_press: root.manager.get_screen(THIS_PAGE).load_completed_audits()
+                on_press: root.manager.get_screen(COMPLETED_AUDITS_LIST_PAGE).load_completed_audits()

--- a/cilantro_audit/widgets/create_completed_audit_page.kv
+++ b/cilantro_audit/widgets/create_completed_audit_page.kv
@@ -3,6 +3,7 @@
     title_label: title_label
     auditor_name: auditor_name
     size: root.width, root.height
+    scrolling_panel: scrolling_panel
 
     Label:
         id: title_label
@@ -41,6 +42,7 @@
     ScrollView:
         size_hint: .8, .89
         pos_hint: {"top": .8}
+        id: scrolling_panel
 
         StackLayout:
             id: stack_list

--- a/cilantro_audit/widgets/create_completed_audit_page.kv
+++ b/cilantro_audit/widgets/create_completed_audit_page.kv
@@ -1,0 +1,67 @@
+<CreateCompletedAuditPage>:
+    stack_list: stack_list
+    title_label: title_label
+    auditor_name: auditor_name
+    size: root.width, root.height
+
+    Label:
+        id: title_label
+        text: "Audit Name:  " + root.audit_title
+        color: 1, 1, 1, 1
+        text_size: root.width-100, None
+        pos_hint: {"top": 1.45}
+
+    GridLayout:
+        cols: 2
+        rows: 2
+        row_force_default: True
+        row_default_height: 30
+        size_hint_y: None
+        size_hint_x: .25
+        pos_hint: {"top": .95}
+
+        Label:
+            id: title_label
+            text: "Audit Name:  " + root.audit_title
+            color: 1, 1, 1, 1
+            text_size: root.width, None
+            pos_hint: {"top": 1.45}
+
+        Label:
+            id: blank_label
+
+        Label:
+            id: name_label
+            text: "Your Name: "
+
+        TextInput:
+            id: auditor_name
+            multiline: False
+
+    ScrollView:
+        size_hint: .8, .89
+        pos_hint: {"top": .8}
+
+        StackLayout:
+            id: stack_list
+            size_hint_y: None
+            minimum_height: 10
+
+            GridLayout:
+                row_force_default: True
+                row_default_height: 30
+                cols: 2
+                spacing: 200
+                size_hint_y: None
+
+    Button:
+        text: "Submit"
+        size_hint: .15, .1
+        pos_hint: {"right": 1, "y": 0}
+        on_press: root.submit_audit_pop(root.manager)
+
+    Button:
+        text: "Back"
+        size_hint: .15, .1
+        pos_hint: {"right": .85, "bottom": 0}
+        on_press: root.back(root.manager)

--- a/cilantro_audit/widgets/home_page.kv
+++ b/cilantro_audit/widgets/home_page.kv
@@ -3,7 +3,7 @@
     FloatLayout:
 
         Label:
-            text: 'Login'
+            text: 'Home Page'
             font_size: 40
             pos: 0, 150
             pos_hint: {"top": 1.21, "center_x": 0.5}

--- a/cilantro_audit/widgets/view_audit_templates.kv
+++ b/cilantro_audit/widgets/view_audit_templates.kv
@@ -102,7 +102,7 @@
     name: 'button_template'
 
     size_hint_y: None
-    on_release:
-        app.root.current = 'ViewAuditTemplates'
-        app.root.transition.duration = 0.3
-        app.root.transition.direction = 'right'
+    #on_release:
+    #    app.root.current = 'ViewAuditTemplates'
+    #    app.root.transition.duration = 0.3
+    #    app.root.transition.direction = 'right'

--- a/cilantro_audit/widgets/view_audit_templates.kv
+++ b/cilantro_audit/widgets/view_audit_templates.kv
@@ -100,5 +100,4 @@
 
 <AuditButton@Button>:
     name: 'button_template'
-
     size_hint_y: None

--- a/cilantro_audit/widgets/view_audit_templates.kv
+++ b/cilantro_audit/widgets/view_audit_templates.kv
@@ -102,7 +102,3 @@
     name: 'button_template'
 
     size_hint_y: None
-    #on_release:
-    #    app.root.current = 'ViewAuditTemplates'
-    #    app.root.transition.duration = 0.3
-    #    app.root.transition.direction = 'right'


### PR DESCRIPTION
## Previews of Changes
![Screenshot from 2019-11-07 17-33-08](https://user-images.githubusercontent.com/20716788/68442030-b4de4d80-0184-11ea-97f2-e70bb7d81177.png)
![Screenshot from 2019-11-07 17-33-14](https://user-images.githubusercontent.com/20716788/68442031-b4de4d80-0184-11ea-82b0-c8d8e31f7e8d.png)

Dynamically allows the auditor to submit an audit based on the name selected in the `view audit templates` screen.