### PR TITLE
Update generate_demo_data.py - no repeat titles (FIXES #115)

### DIFF
--- a/cilantro_audit/generate_demo_data.py
+++ b/cilantro_audit/generate_demo_data.py
@@ -22,6 +22,7 @@ TITLES = [
     "Bathroom #2",
     "Ink Room",
     "Plating Room",
+    "Engine Room",
     "Break Room",
     "Lunch Room",
     "Lobby",
@@ -137,9 +138,8 @@ def random_answer_from_question(question):
 
 
 if __name__ == '__main__':
-    for _ in range(NUM_TEMPLATES):
+    for title in TITLES:
         time.sleep(DELAY)
-        title = random_title()
         q0 = random_question()
         q1 = random_question()
         q2 = random_question()
@@ -157,7 +157,7 @@ if __name__ == '__main__':
             .save()
 
         for _ in range(NUM_COMPLETED_PER_TEMPLATE):
-            time.sleep(1.000)
+            time.sleep(DELAY)
             CompletedAuditBuilder() \
                 .with_title(title) \
                 .with_auditor(random.choice(AUDITORS)) \


### PR DESCRIPTION
Very small changes. This is already enforced when a user creates a template, just making sure our dummy data follows the same convention.