### PR TITLE
Ticket-132: Change Color of Severity Text to Match Name in Viewing Completed Audits (Admin)

### DIFF
--- a/cilantro_audit/auditor_completed_audit_page.py
+++ b/cilantro_audit/auditor_completed_audit_page.py
@@ -73,21 +73,6 @@ class AuditorCompletedAuditPage(Screen):
         lbl = Label(text=text, size_hint_y=None, height=40, halign="left")
         self.grid_list.add_widget(lbl)
 
-    def add_question_answer(self, question, answer):
-        self.stack_list.height += 80  # integer (80) comes from question_answer size
-        qa = AuditorQuestionAnswer()
-        qa.question_text = "[b]Question: [/b]" + question.text
-        qa.answer_response_text = "[b]Response: [/b]" + str(answer.response.response)
-        qa.answer_comments_text = "[b]Comments: [/b]" + str(answer.comment)
-        qa.answer_severity_text = "[b]Severity: [/b]" + str(answer.severity.severity)
-        if qa.answer_severity_text == "[b]Severity: [/b]RED":
-            qa.answer_severity_text = "[b]Severity: [/b][color=" + RGB_RED + "]RED[/color]"
-        elif qa.answer_severity_text == "[b]Severity: [/b]YELLOW":
-            qa.answer_severity_text = "[b]Severity: [/b][color=" + RGB_YELLOW + "]YELLOW[/color]"
-        elif qa.answer_severity_text == "[b]Severity: [/b]GREEN":
-            qa.answer_severity_text = "[b]Severity: [/b][color=" + RGB_GREEN + "]GREEN[/color]"
-        self.stack_list.add_widget(qa)
-
     def add_question_answer_auditor_version(self, question, answer):
         self.stack_list.height += 80  # integer (80) comes from question_answer size
         qa = AuditorQuestionAnswer()

--- a/cilantro_audit/completed_audit_page.py
+++ b/cilantro_audit/completed_audit_page.py
@@ -4,11 +4,12 @@ from kivy.properties import ObjectProperty, StringProperty
 from kivy.uix.floatlayout import FloatLayout
 from kivy.uix.label import Label
 from kivy.uix.screenmanager import Screen
+from kivy.utils import get_hex_from_color
 from mongoengine import connect
 
 from cilantro_audit.completed_audit import CompletedAudit
 from cilantro_audit.audit_template import AuditTemplate
-from cilantro_audit.constants import KIVY_REQUIRED_VERSION, PROD_DB
+from cilantro_audit.constants import KIVY_REQUIRED_VERSION, PROD_DB, RGB_RED, RGB_YELLOW, RGB_GREEN
 
 kivy.require(KIVY_REQUIRED_VERSION)
 
@@ -84,19 +85,11 @@ class CompletedAuditPage(Screen):
         qa.answer_comments_text = "[b]Comments: [/b]" + str(answer.comment)
         qa.answer_severity_text = "[b]Severity: [/b]" + str(answer.severity.severity)
         if qa.answer_severity_text == "[b]Severity: [/b]RED":
-            qa.answer_severity_text = "[b]Severity: [/b][color=#ed1c1c]RED[/color]"
+            qa.answer_severity_text = "[b]Severity: [/b][color="+get_hex_from_color(RGB_RED)+"]RED[/color]"
         elif qa.answer_severity_text == "[b]Severity: [/b]YELLOW":
-            qa.answer_severity_text = "[b]Severity: [/b][color=#fbff21]YELLOW[/color]"
+            qa.answer_severity_text = "[b]Severity: [/b][color="+get_hex_from_color(RGB_YELLOW)+"]YELLOW[/color]"
         elif qa.answer_severity_text == "[b]Severity: [/b]GREEN":
-            qa.answer_severity_text = "[b]Severity: [/b][color=#21ff2c]GREEN[/color]"
-        self.stack_list.add_widget(qa)
-
-    def add_question_answer_auditor_version(self, question, answer):
-        self.stack_list.height += 80  # integer (80) comes from question_answer size
-        qa = QuestionAnswer()
-        qa.question_text = "[b]Question: [/b]" + question.text
-        qa.answer_response_text = "[b]Response: [/b]" + str(answer.response.response)
-        qa.answer_comments_text = "[b]Comments: [/b]" + str(answer.comment)
+            qa.answer_severity_text = "[b]Severity: [/b][color="+get_hex_from_color(RGB_GREEN)+"]GREEN[/color]"
         self.stack_list.add_widget(qa)
 
     def clear_page(self):

--- a/cilantro_audit/completed_audits_list_page.py
+++ b/cilantro_audit/completed_audits_list_page.py
@@ -208,7 +208,8 @@ class CompletedAuditsListPage(Screen):
                 self.auditor_col.add_widget(lbl)
 
             for severity in audit_severities:
-                lbl = Label(text=severity.severity, color=get_severity_color(severity.severity), size_hint_y=None, height=40)
+                lbl = Label(text=severity.severity, color=get_severity_color(severity.severity), size_hint_y=None,
+                            height=40)
                 self.severity_col.add_widget(lbl)
 
             for count in audit_unresolved_counts:

--- a/cilantro_audit/completed_audits_list_page.py
+++ b/cilantro_audit/completed_audits_list_page.py
@@ -12,7 +12,8 @@ from kivy.uix.popup import Popup
 from kivy.clock import Clock
 
 from cilantro_audit.completed_audit import CompletedAudit
-from cilantro_audit.constants import KIVY_REQUIRED_VERSION, PROD_DB, SEVERITY_PRECEDENCE, COMPLETED_AUDIT_PAGE
+from cilantro_audit.constants import KIVY_REQUIRED_VERSION, PROD_DB, SEVERITY_PRECEDENCE, COMPLETED_AUDIT_PAGE, \
+    RGB_RED, RGB_YELLOW, RGB_GREEN
 from cilantro_audit.audit_template import AuditTemplate
 
 kivy.require(KIVY_REQUIRED_VERSION)
@@ -40,11 +41,11 @@ def invert_datetime(dt):
 
 def get_severity_color(severity):
     if severity == "RED":
-        return kivy.utils.rgba("#ed1c1c")
+        return RGB_RED
     if severity == "YELLOW":
-        return kivy.utils.rgba("#fbff21")
+        return RGB_YELLOW
     if severity == "GREEN":
-        return kivy.utils.rgba("#21ff2c")
+        return RGB_GREEN
 
 
 class CompletedAuditsListPage(Screen):

--- a/cilantro_audit/completed_audits_list_page.py
+++ b/cilantro_audit/completed_audits_list_page.py
@@ -38,6 +38,15 @@ def invert_datetime(dt):
     return -(dt - EPOCH).total_seconds()
 
 
+def get_severity_color(severity):
+    if severity == "RED":
+        return kivy.utils.rgba("#ed1c1c")
+    if severity == "YELLOW":
+        return kivy.utils.rgba("#fbff21")
+    if severity == "GREEN":
+        return kivy.utils.rgba("#21ff2c")
+
+
 class CompletedAuditsListPage(Screen):
     date_col = ObjectProperty()
     title_col = ObjectProperty()
@@ -142,7 +151,8 @@ class CompletedAuditsListPage(Screen):
             self.auditor_col.add_widget(lbl)
 
         for severity in audit_severities:
-            lbl = Label(text=severity.severity, size_hint_y=None, height=40)
+            lbl = Label(text=severity.severity, color=get_severity_color(severity.severity), size_hint_y=None,
+                        height=40)
             self.severity_col.add_widget(lbl)
 
         for count in audit_unresolved_counts:
@@ -197,7 +207,7 @@ class CompletedAuditsListPage(Screen):
                 self.auditor_col.add_widget(lbl)
 
             for severity in audit_severities:
-                lbl = Label(text=severity.severity, size_hint_y=None, height=40)
+                lbl = Label(text=severity.severity, color=get_severity_color(severity.severity), size_hint_y=None, height=40)
                 self.severity_col.add_widget(lbl)
 
             for count in audit_unresolved_counts:
@@ -248,7 +258,7 @@ class CompletedAuditsListPage(Screen):
         self.manager.get_screen(COMPLETED_AUDIT_PAGE).reset_scroll_to_top()
 
         for question in audit_template.questions:
-            self.manager.get_screen(COMPLETED_AUDIT_PAGE)\
+            self.manager.get_screen(COMPLETED_AUDIT_PAGE) \
                 .add_question_answer(question, completed_audit.answers[counter])
             counter += 1
 


### PR DESCRIPTION
## Changes
- Severity text now corresponds to a specific color
- This also applies when searching/filtering is done as well

## Preview
![Screenshot from 2019-11-21 15-19-21](https://user-images.githubusercontent.com/20716788/69384848-516b1a00-0c72-11ea-8deb-88c1369111ff.png)
![Screenshot from 2019-11-21 15-19-07](https://user-images.githubusercontent.com/20716788/69384849-5203b080-0c72-11ea-9da2-a258ba1e56c0.png)

