### PR TITLE
Completed Audit Page Fix

### DIFF
--- a/cilantro_audit/auditor_completed_audit_page.py
+++ b/cilantro_audit/auditor_completed_audit_page.py
@@ -36,20 +36,6 @@ class AuditorCompletedAuditPage(Screen):
 
     def __init__(self, **kw):
         super().__init__(**kw)
-        self.completed_audits = []
-        self.audit_templates = []
-        self.load_completed_audits()
-        self.load_audit_templates()
-
-    # Loads all of the completed_audit objects from the database into a list.
-    def load_completed_audits(self):
-        self.completed_audits = list(CompletedAudit.objects().all_fields())
-        self.completed_audits = sorted(self.completed_audits, key=lambda completed_audit: completed_audit.title)
-
-    # Loads all of the audit_template objects from the database into a list.
-    def load_audit_templates(self):
-        self.audit_templates = list(AuditTemplate.objects().all_fields())
-        self.audit_templates = sorted(self.audit_templates, key=lambda audit_template: audit_template.title)
 
     def reset_scroll_to_top(self):  # needs to be used in the routine that first populates the questions.
         # https://kivy.org/doc/stable/api-kivy.uix.scrollview.html Y scrolling value, between 0 and 1. If 0,
@@ -73,10 +59,10 @@ class AuditorCompletedAuditPage(Screen):
         lbl = Label(text=text, size_hint_y=None, height=40, halign="left")
         self.grid_list.add_widget(lbl)
 
-    def add_question_answer_auditor_version(self, question, answer):
+    def add_question_answer_auditor_version(self, answer):
         self.stack_list.height += 80  # integer (80) comes from question_answer size
         qa = AuditorQuestionAnswer()
-        qa.question_text = "[b]Question: [/b]" + question.text
+        qa.question_text = "[b]Question: [/b]" + answer.text
         qa.answer_response_text = "[b]Response: [/b]" + str(answer.response.response)
         qa.answer_comments_text = "[b]Comments: [/b]" + str(answer.comment)
         self.stack_list.add_widget(qa)

--- a/cilantro_audit/auditor_completed_audits_list_page.py
+++ b/cilantro_audit/auditor_completed_audits_list_page.py
@@ -96,46 +96,32 @@ class AuditorCompletedAuditsListPage(Screen):
         self.manager.get_screen(AUDITOR_COMPLETED_AUDIT_PAGE).add_auditor(auditor)
         self.manager.get_screen(AUDITOR_COMPLETED_AUDIT_PAGE).add_date_time(format_datetime(utc_to_local(dt)))
 
-    def load_audit_template_and_completed_audit_with_title_and_datetime(self, title, timedate):
-        at = AuditTemplate()
-        ca = CompletedAudit()
+    def load_audit_template_and_completed_audit_with_title_and_datetime(self, dt):
+        ca = list(CompletedAudit.objects(datetime=dt))
 
-        ca_list = list(CompletedAudit.objects().only("title", "datetime", "auditor", "severity", "answers"))
+        return ca[0]
 
-        for audit_template in self.audit_templates:
-            if audit_template.title == title:
-                at = audit_template
-                break
-
-        for completed_audit in ca_list:
-            if str(completed_audit.datetime) == timedate:
-                ca = completed_audit
-                break
-        return at, ca
-
-    def build_completed_audit_page_body(self, audit_template, completed_audit):
-        counter = 0
+    def build_completed_audit_page_body(self, completed_audit):
 
         # Have to set the scroll so there is not a major gap.
         self.manager.get_screen(AUDITOR_COMPLETED_AUDIT_PAGE).stack_list.clear_widgets()
         self.manager.get_screen(AUDITOR_COMPLETED_AUDIT_PAGE).stack_list.height = 0
         self.manager.get_screen(AUDITOR_COMPLETED_AUDIT_PAGE).reset_scroll_to_top()
 
-        for question in audit_template.questions:
-            self.manager.get_screen(AUDITOR_COMPLETED_AUDIT_PAGE)\
-                .add_question_answer_auditor_version(question, completed_audit.answers[counter])
-            counter += 1
+        for answer in completed_audit.answers:
+            self.manager.get_screen(AUDITOR_COMPLETED_AUDIT_PAGE) \
+                .add_question_answer_auditor_version(answer)
 
-    def populate_completed_audit_page(self, title, dt):
-        at, ca = self.load_audit_template_and_completed_audit_with_title_and_datetime(title, dt)
+    def populate_completed_audit_page(self, title):
+        ca = self.load_audit_template_and_completed_audit_with_title_and_datetime(title)
         self.build_header_row(ca.title, ca.datetime, ca.auditor)
 
-        self.build_completed_audit_page_body(at, ca)
+        self.build_completed_audit_page_body(ca)
 
         self.manager.current = AUDITOR_COMPLETED_AUDIT_PAGE
 
     def callback(self, instance):
-        self.populate_completed_audit_page(instance.text, instance.id)
+        self.populate_completed_audit_page(instance.id)
 
 
 def format_datetime(dt):

--- a/cilantro_audit/completed_audit_page.py
+++ b/cilantro_audit/completed_audit_page.py
@@ -40,20 +40,6 @@ class CompletedAuditPage(Screen):
 
     def __init__(self, **kw):
         super().__init__(**kw)
-        self.completed_audits = []
-        self.audit_templates = []
-        self.load_completed_audits()
-        self.load_audit_templates()
-
-    # Loads all of the completed_audit objects from the database into a list.
-    def load_completed_audits(self):
-        self.completed_audits = list(CompletedAudit.objects().all_fields())
-        self.completed_audits = sorted(self.completed_audits, key=lambda completed_audit: completed_audit.title)
-
-    # Loads all of the audit_template objects from the database into a list.
-    def load_audit_templates(self):
-        self.audit_templates = list(AuditTemplate.objects().all_fields())
-        self.audit_templates = sorted(self.audit_templates, key=lambda audit_template: audit_template.title)
 
     def reset_scroll_to_top(self):  # needs to be used in the routine that first populates the questions.
         # https://kivy.org/doc/stable/api-kivy.uix.scrollview.html Y scrolling value, between 0 and 1. If 0,
@@ -77,10 +63,10 @@ class CompletedAuditPage(Screen):
         lbl = Label(text=text, size_hint_y=None, height=40, halign="left")
         self.grid_list.add_widget(lbl)
 
-    def add_question_answer(self, question, answer):
+    def add_question_answer(self, answer):
         self.stack_list.height += 80  # integer (80) comes from question_answer size
         qa = QuestionAnswer()
-        qa.question_text = "[b]Question: [/b]" + question.text
+        qa.question_text = "[b]Question: [/b]" + answer.text
         qa.answer_response_text = "[b]Response: [/b]" + str(answer.response.response)
         qa.answer_comments_text = "[b]Comments: [/b]" + str(answer.comment)
         qa.answer_severity_text = "[b]Severity: [/b]" + str(answer.severity.severity)

--- a/cilantro_audit/completed_audits_list_page.py
+++ b/cilantro_audit/completed_audits_list_page.py
@@ -234,17 +234,10 @@ class CompletedAuditsListPage(Screen):
         self.manager.get_screen(COMPLETED_AUDIT_PAGE).add_auditor(auditor)
         self.manager.get_screen(COMPLETED_AUDIT_PAGE).add_date_time(format_datetime(utc_to_local(dt)))
 
-    def load_audit_template_and_completed_audit_with_title_and_datetime(self, datetime):
-        ca = CompletedAudit()
+    def load_audit_template_and_completed_audit_with_title_and_datetime(self, dt):
+        ca = list(CompletedAudit.objects(datetime=dt))
 
-        ca_list = list(CompletedAudit.objects().only("title", "datetime", "auditor", "severity", "answers"))
-
-        for completed_audit in ca_list:
-            if str(completed_audit.datetime) == datetime:
-                ca = completed_audit
-                break
-
-        return ca
+        return ca[0]
 
     def build_completed_audit_page_body(self, completed_audit):
 

--- a/cilantro_audit/completed_audits_list_page.py
+++ b/cilantro_audit/completed_audits_list_page.py
@@ -234,46 +234,39 @@ class CompletedAuditsListPage(Screen):
         self.manager.get_screen(COMPLETED_AUDIT_PAGE).add_auditor(auditor)
         self.manager.get_screen(COMPLETED_AUDIT_PAGE).add_date_time(format_datetime(utc_to_local(dt)))
 
-    def load_audit_template_and_completed_audit_with_title_and_datetime(self, title, datetime):
-        at = AuditTemplate()
+    def load_audit_template_and_completed_audit_with_title_and_datetime(self, datetime):
         ca = CompletedAudit()
 
         ca_list = list(CompletedAudit.objects().only("title", "datetime", "auditor", "severity", "answers"))
-
-        for audit_template in self.audit_templates:
-            if audit_template.title == title:
-                at = audit_template
-                break
 
         for completed_audit in ca_list:
             if str(completed_audit.datetime) == datetime:
                 ca = completed_audit
                 break
-        return at, ca
 
-    def build_completed_audit_page_body(self, audit_template, completed_audit):
-        counter = 0
+        return ca
+
+    def build_completed_audit_page_body(self, completed_audit):
 
         # Have to set the scroll so there is not a major gap.
         self.manager.get_screen(COMPLETED_AUDIT_PAGE).stack_list.clear_widgets()
         self.manager.get_screen(COMPLETED_AUDIT_PAGE).stack_list.height = 0
         self.manager.get_screen(COMPLETED_AUDIT_PAGE).reset_scroll_to_top()
 
-        for question in audit_template.questions:
+        for answer in completed_audit.answers:
             self.manager.get_screen(COMPLETED_AUDIT_PAGE) \
-                .add_question_answer(question, completed_audit.answers[counter])
-            counter += 1
+                .add_question_answer(answer)
 
-    def populate_completed_audit_page(self, title, dt):
-        at, ca = self.load_audit_template_and_completed_audit_with_title_and_datetime(title, dt)
+    def populate_completed_audit_page(self, title):
+        ca = self.load_audit_template_and_completed_audit_with_title_and_datetime(title)
         self.build_header_row(ca.title, ca.datetime, ca.auditor)
 
-        self.build_completed_audit_page_body(at, ca)
+        self.build_completed_audit_page_body(ca)
 
         self.manager.current = COMPLETED_AUDIT_PAGE
 
     def callback(self, instance):
-        self.populate_completed_audit_page(instance.text, instance.id)
+        self.populate_completed_audit_page(instance.id)
 
 
 # Class defining the search popup


### PR DESCRIPTION
Responses to a newly created audit template would not load when clicked on in the completed audit list page. After restarting the application, the responses would load properly. This bug was caused by not loading an updated list of audit templates in the "load_audit_template_and_completed_audit_with_title_and_datetime" method in completed_audit_list_page.py. To fix this bug I removed the instances where the audit template were being used in:

load_audit_template_and_completed_audit_with_title_and_datetime
build_completed_audit_page_body
populate_completed_audit_page

As all of the information needed by the completed audit page can be supplied by the completed audit answer. I also changed how the completed audit was found from a loop to a DB query. In completed_audit_page.py I removed the methods that queried the DB as they did not seem to have a use in the page.