### PR TITLE
Add new language to flag trends page

### DIFF
--- a/cilantro_audit/admin_page.py
+++ b/cilantro_audit/admin_page.py
@@ -34,7 +34,7 @@ class AdminPage(Screen):
                                                               size_hint_y=None,
                                                               height=70,
                                                               on_release=view_submitted_audits_page))
-        template_page.body_nav_btns.add_widget(CilantroButton(text='View Flag Trends',
+        template_page.body_nav_btns.add_widget(CilantroButton(text='Repeated Findings Trends',
                                                               size_hint_y=None,
                                                               height=70,
                                                               on_release=view_flag_trends))

--- a/cilantro_audit/view_flag_trends_page.py
+++ b/cilantro_audit/view_flag_trends_page.py
@@ -33,7 +33,7 @@ class ViewFlagTrendsPage(Screen):
     def populate_page(self):
         self.clear_widgets()
         template_page = CilantroPage()
-        template_page.header_title.text = 'Flagged Questions Trend'
+        template_page.header_title.text = 'Repeated Findings Trends'
 
         template_page.footer_back.bind(on_release=go_back)
 

--- a/cilantro_audit/widgets/view_flag_trends_page.kv
+++ b/cilantro_audit/widgets/view_flag_trends_page.kv
@@ -64,7 +64,7 @@
                                 root.sort_by_question()
 
                         CilantroButton:
-                            text: 'Flagged Answers'
+                            text: 'Number of Findings'
                             on_release:
                                 root.sort_by_times_flagged()
 


### PR DESCRIPTION
Gives a new title to `view_flags_trends_page` as requested to use 'findings' in place of 'answers' or 'flags.' The user facing labels are all that was changed, internally flag trends is still used.
![ticket-172](https://user-images.githubusercontent.com/38013435/70192843-f1cd2f80-16b1-11ea-9f7b-508d2d091252.gif)
