### PR TITLE
Delete an audit template

### DIFF
--- a/cilantro_audit/admin_page.py
+++ b/cilantro_audit/admin_page.py
@@ -42,6 +42,10 @@ class AdminPage(Screen):
                                                               size_hint_y=None,
                                                               height=70,
                                                               on_release=clear_all_audit_locks))
+        template_page.body_nav_btns.add_widget(CilantroButton(text='View Audit Forms',
+                                                              size_hint_y=None,
+                                                              height=70,
+                                                              on_release=view_audit_templates_admin))
 
         template_page.footer_logout.text = 'LOGOUT'
         template_page.footer_logout.bind(on_release=logout)
@@ -65,6 +69,11 @@ def view_flag_trends(callback):
 def clear_all_audit_locks(callback):
     AuditTemplate.objects().update(upsert=False, multi=True, locked=False)
     TemplatesUnlockedPop().open()
+
+
+def view_audit_templates_admin(callback):
+    globals.screen_manager.get_screen(globals.VIEW_AUDIT_TEMPLATES_ADMIN).populate_page()
+    globals.screen_manager.current = globals.VIEW_AUDIT_TEMPLATES_ADMIN
 
 
 def logout(callback):

--- a/cilantro_audit/admin_page.py
+++ b/cilantro_audit/admin_page.py
@@ -43,7 +43,7 @@ class AdminPage(Screen):
                                                               size_hint_y=None,
                                                               height=70,
                                                               on_release=clear_all_audit_locks))
-        template_page.body_nav_btns.add_widget(CilantroButton(text='View Audit Forms',
+        template_page.body_nav_btns.add_widget(CilantroButton(text='Delete Audit Forms',
                                                               size_hint_y=None,
                                                               height=70,
                                                               on_release=view_audit_templates_admin))

--- a/cilantro_audit/completed_audit_page.py
+++ b/cilantro_audit/completed_audit_page.py
@@ -47,7 +47,7 @@ class CompletedAuditPage(Screen):
         self.grid_list.add_widget(lbl)
 
     # Needs to be updated when you click out of one audit and load up another
-    def add_date_time(self, dt):
+    def add_datetime(self, dt):
         lbl = Label(text='[b]Date: [/b]' + dt, markup=True, size_hint_y=None, height=40, halign="left")
         self.grid_list.add_widget(lbl)
 

--- a/cilantro_audit/constants.py
+++ b/cilantro_audit/constants.py
@@ -44,6 +44,7 @@ CREATE_AUDIT_TEMPLATE_PAGE = "CreateAuditTemplatePage"
 CREATE_COMPLETED_AUDIT_PAGE = "CreateCompletedAuditPage"
 VIEW_AUDIT_TEMPLATES = "ViewAuditTemplates"
 VIEW_FLAG_TRENDS_PAGE = "ViewFlagTrendsPage"
+VIEW_AUDIT_TEMPLATES_ADMIN = "ViewAuditTemplatesAdmin"
 
 # Theme Colors
 CILANTRO_BLACK_THEME = get_color_from_hex("#000000")

--- a/cilantro_audit/globals.py
+++ b/cilantro_audit/globals.py
@@ -14,6 +14,7 @@ from cilantro_audit.view_flag_trends_page import ViewFlagTrendsPage
 from cilantro_audit.create_completed_audit_page import CreateCompletedAuditPage
 from cilantro_audit.completed_audit_page import CompletedAuditPage
 from cilantro_audit.auditor_completed_audit_page import AuditorCompletedAuditPage
+from cilantro_audit.view_audit_templates_admin import ViewAuditTemplatesAdmin
 
 from cilantro_audit.constants import KIVY_REQUIRED_VERSION
 from cilantro_audit.constants import HOME_SCREEN
@@ -27,6 +28,7 @@ from cilantro_audit.constants import AUDITOR_COMPLETED_AUDIT_PAGE
 from cilantro_audit.constants import AUDITOR_COMPLETED_AUDITS_LIST_PAGE
 from cilantro_audit.constants import VIEW_AUDIT_TEMPLATES
 from cilantro_audit.constants import VIEW_FLAG_TRENDS_PAGE
+from cilantro_audit.constants import VIEW_AUDIT_TEMPLATES_ADMIN
 
 require(KIVY_REQUIRED_VERSION)
 
@@ -65,3 +67,4 @@ screen_manager.add_widget(AuditorCompletedAuditPage(name=AUDITOR_COMPLETED_AUDIT
 screen_manager.add_widget(AuditorCompletedAuditsListPage(name=AUDITOR_COMPLETED_AUDITS_LIST_PAGE))
 screen_manager.add_widget(ViewAuditTemplates(name=VIEW_AUDIT_TEMPLATES))
 screen_manager.add_widget(ViewFlagTrendsPage(name=VIEW_FLAG_TRENDS_PAGE))
+screen_manager.add_widget((ViewAuditTemplatesAdmin(name=VIEW_AUDIT_TEMPLATES_ADMIN)))

--- a/cilantro_audit/globals.py
+++ b/cilantro_audit/globals.py
@@ -51,6 +51,7 @@ Builder.load_file("./widgets/auditor_completed_audit_page.kv")
 Builder.load_file("./widgets/auditor_completed_audits_list_page.kv")
 Builder.load_file("./widgets/view_audit_templates.kv")
 Builder.load_file("./widgets/view_flag_trends_page.kv")
+Builder.load_file("./widgets/view_audit_templates_admin.kv")
 
 # App Screen Manager
 screen_manager = ScreenManager()

--- a/cilantro_audit/view_audit_templates_admin.py
+++ b/cilantro_audit/view_audit_templates_admin.py
@@ -26,7 +26,7 @@ class ViewAuditTemplatesAdmin(Screen):
     def populate_page(self):
         self.clear_widgets()
         template_page = CilantroPage()
-        template_page.header_title.text = 'All Audits'
+        template_page.header_title.text = 'All Audits (Click to delete)'
 
         template_page.body.add_widget(ViewAuditTemplatesContent())
 
@@ -39,7 +39,7 @@ class ViewAuditTemplatesAdmin(Screen):
 
 
 def go_back(callback):
-    globals.screen_manager.current = globals.AUDITOR_SCREEN
+    globals.screen_manager.current = globals.ADMIN_SCREEN
 
 
 def refresh(callback):
@@ -57,14 +57,32 @@ class ViewAuditTemplatesContent(Screen):
         self.templates_list.clear_widgets()
 
         for audit in list(AuditTemplate.objects()):
-            self.templates_list.add_widget(ActiveAuditButton(text=audit.title))
+            self.templates_list.add_widget(AuditButton(text=audit.title))
 
 
-class ActiveAuditButton(CilantroButton):
+class DeletePop(Popup):
+    audit_title = ObjectProperty(None)
+    yes = ObjectProperty(None)
+
+
+class ConfirmPop(Popup):
+    ok = ObjectProperty(None)
+
+
+# todo Make the page automatically refresh when an audit is deleted.
+class AuditButton(CilantroButton):
     def on_release(self, *args):
         super().on_release(*args)
-        globals.screen_manager.current = CREATE_COMPLETED_AUDIT_PAGE
-        globals.screen_manager.get_screen(CREATE_COMPLETED_AUDIT_PAGE).populate_page(self.text)
+        show = DeletePop()
+        show.yes.bind(on_release=lambda _: self.delete_audit())
+        show.audit_title.text = self.text + "?"
+        show.open()
+
+    def delete_audit(self):
+        to_delete = AuditTemplate.objects(title=self.text)
+        to_delete.delete()
+        show = ConfirmPop()
+        show.open()
 
 
 class TestApp(App):

--- a/cilantro_audit/view_audit_templates_admin.py
+++ b/cilantro_audit/view_audit_templates_admin.py
@@ -26,7 +26,7 @@ class ViewAuditTemplatesAdmin(Screen):
     def populate_page(self):
         self.clear_widgets()
         template_page = CilantroPage()
-        template_page.header_title.text = 'All Audits (Click to delete)'
+        template_page.header_title.text = 'Delete Audit Forms (Click to delete)'
 
         template_page.body.add_widget(ViewAuditTemplatesContent())
 

--- a/cilantro_audit/view_audit_templates_admin.py
+++ b/cilantro_audit/view_audit_templates_admin.py
@@ -1,0 +1,76 @@
+from kivy.app import App
+from kivy.properties import ObjectProperty
+from kivy.uix.popup import Popup
+from kivy.uix.screenmanager import Screen
+
+from cilantro_audit import globals
+
+from cilantro_audit.constants import PROD_DB
+from cilantro_audit.constants import CREATE_COMPLETED_AUDIT_PAGE
+
+from cilantro_audit.audit_template import AuditTemplate
+
+from cilantro_audit.templates.cilantro_page import CilantroPage
+from cilantro_audit.templates.cilantro_button import CilantroButton
+
+from mongoengine import connect
+
+connect(PROD_DB)
+
+
+class ViewAuditTemplatesAdmin(Screen):
+    def __init__(self, **kw):
+        super().__init__(**kw)
+        self.populate_page()
+
+    def populate_page(self):
+        self.clear_widgets()
+        template_page = CilantroPage()
+        template_page.header_title.text = 'All Audits'
+
+        template_page.body.add_widget(ViewAuditTemplatesContent())
+
+        template_page.footer_back.bind(on_release=go_back)
+
+        template_page.footer_refresh.text = 'Refresh Page'
+        template_page.footer_refresh.bind(on_release=refresh)
+
+        self.add_widget(template_page)
+
+
+def go_back(callback):
+    globals.screen_manager.current = globals.AUDITOR_SCREEN
+
+
+def refresh(callback):
+    globals.screen_manager.get_screen(globals.VIEW_AUDIT_TEMPLATES).populate_page()
+
+
+class ViewAuditTemplatesContent(Screen):
+    templates_list = ObjectProperty()
+
+    def __init__(self, **kw):
+        super().__init__(**kw)
+        self.populate_content()
+
+    def populate_content(self):
+        self.templates_list.clear_widgets()
+
+        for audit in list(AuditTemplate.objects()):
+            self.templates_list.add_widget(ActiveAuditButton(text=audit.title))
+
+
+class ActiveAuditButton(CilantroButton):
+    def on_release(self, *args):
+        super().on_release(*args)
+        globals.screen_manager.current = CREATE_COMPLETED_AUDIT_PAGE
+        globals.screen_manager.get_screen(CREATE_COMPLETED_AUDIT_PAGE).populate_page(self.text)
+
+
+class TestApp(App):
+    def build(self):
+        return ViewAuditTemplatesAdmin()
+
+
+if __name__ == '__main__':
+    TestApp().run()

--- a/cilantro_audit/view_audit_templates_admin.py
+++ b/cilantro_audit/view_audit_templates_admin.py
@@ -43,7 +43,7 @@ def go_back(callback):
 
 
 def refresh(callback):
-    globals.screen_manager.get_screen(globals.VIEW_AUDIT_TEMPLATES).populate_page()
+    globals.screen_manager.get_screen(globals.VIEW_AUDIT_TEMPLATES_ADMIN).populate_page()
 
 
 class ViewAuditTemplatesContent(Screen):

--- a/cilantro_audit/widgets/view_audit_templates_admin.kv
+++ b/cilantro_audit/widgets/view_audit_templates_admin.kv
@@ -76,10 +76,73 @@
             size_hint: 0.1, 0.1
 
 
-<ActiveAuditButton@CilantroButton>:
+<AuditButton@CilantroButton>:
     name: 'active_button_template'
     size_hint_y: None
     height: 70
 
     on_release:
         self.text
+
+<DeletePop>:
+    auto_dismiss: False
+    title: "Confirm Delete"
+    size_hint: .5, .5
+    audit_title: audit_title
+    yes: yes
+
+    FloatLayout:
+        Label:
+            id: confirm_message
+            text: "Are you sure you want to delete"
+            text_width: self.width, None
+            font_size: root.width/20
+            size_hint: 1, None
+            height: self.texture_size[1]
+            pos_hint: {"x": 0, "top": .9}
+        Label:
+            id: audit_title
+            text_width: self.width, None
+            font_size: root.width/20
+            size_hint: 1, None
+            height: self.texture_size[1]
+            pos_hint: {"x": 0, "top": .75}
+
+        Button:
+            text: "No"
+            font_size: root.width/30
+            size_hint: .3, .3
+            pos_hint: {"center_x": .25, "y": 0.05}
+            on_release:
+                root.dismiss()
+
+        Button:
+            text: "Yes"
+            id: yes
+            font_size: root.width/30
+            size_hint: .3, .3
+            pos_hint: {"center_x": .75, "y": 0.05}
+
+            on_release:
+                root.dismiss()
+
+<ConfirmPop>:
+    auto_dismiss: False
+    title: "Audit Deleted"
+    size_hint: .5, .5
+    ok: ok
+
+    FloatLayout:
+        Label:
+            text: "Audit deleted, please refresh the page"
+            font_size: root.width/20
+            size_hint: 1, None
+            pos_hint: {"center_x": 0.5, "top": .75}
+
+        Button:
+            text: "Ok"
+            id: ok
+            font_size: root.width/30
+            size_hint: .3, .3
+            pos_hint: {"y": 0.05, "x": 0.35}
+            on_release: root.dismiss()

--- a/cilantro_audit/widgets/view_audit_templates_admin.kv
+++ b/cilantro_audit/widgets/view_audit_templates_admin.kv
@@ -52,11 +52,9 @@
             name: 'place-holder'
             size_hint: 0.1, 0.1
 
-        CilantroButton:
-            text: 'Refresh List'
-            size_hint: 1, 0.1
-            on_release:
-                root.populate_content()
+        Widget:
+            name: 'place-holder'
+            size_hint: 0.1, 0.1
 
         Widget:
             name: 'place-holder'

--- a/cilantro_audit/widgets/view_audit_templates_admin.kv
+++ b/cilantro_audit/widgets/view_audit_templates_admin.kv
@@ -1,0 +1,85 @@
+#:import CILANTRO_BLACK_THEME cilantro_audit.constants.CILANTRO_BLACK_THEME
+
+<ViewAuditTemplates>:
+
+
+<ViewAuditTemplatesContent>:
+    templates_list: templates_list
+
+    GridLayout:
+        rows: 4
+        cols: 3
+
+        # 1st Row
+        Widget:
+            name: 'place-holder'
+            size_hint: 0.1, 0.1
+
+        Widget:
+            name: 'place-holder'
+            size_hint: 1, 0.1
+
+        Widget:
+            name: 'place-holder'
+            size_hint: 0.1, 0.1
+
+        # 2nd Row
+        Widget:
+            name: 'place-holder'
+            size_hint: 0.1, 1
+
+        GridLayout:
+            rows: 2
+            cols: 1
+
+            GridLayout:
+                rows: 2
+                cols: 1
+
+                ScrollView:
+                    StackLayout:
+                        id: templates_list
+                        height: self.minimum_height
+                        size_hint: 1, None
+                        spacing: 2
+
+        Widget:
+            name: 'place-holder'
+            size_hint: 0.1, 1
+
+        # 3rd Row
+        Widget:
+            name: 'place-holder'
+            size_hint: 0.1, 0.1
+
+        CilantroButton:
+            text: 'Refresh List'
+            size_hint: 1, 0.1
+            on_release:
+                root.populate_content()
+
+        Widget:
+            name: 'place-holder'
+            size_hint: 0.1, 0.1
+
+        # 4th Row
+        Widget:
+            name: 'place-holder'
+            size_hint: 0.1, 0.1
+
+        Widget:
+            name: 'place-holder'
+            size_hint: 1, 0.1
+
+        Widget:
+            name: 'place-holder'
+            size_hint: 0.1, 0.1
+
+
+<ActiveAuditButton@CilantroButton>:
+    name: 'active_button_template'
+    size_hint_y: None
+    height: 70
+
+    on_release:
+        self.text


### PR DESCRIPTION
Adds the functionality of deleting an audit template when in the admin menu.

![delete-templates](https://user-images.githubusercontent.com/38013435/70205363-a24e2a00-16d8-11ea-9392-07fdb3d750c3.gif)

Creates a new page for viewing audit templates in the admin menu, with the functionality of deleting them when clicked. Copies already existing templates from the auditor's `view_audit_templates` page, and removes unnecessary functionality (locked out audits). 

There are two popups for deleting an audit template. The first asks for confirmation to delete the audit, and the second confirms to the user that the audit has been deleted. A later update should make the page refresh after the popups close.

Deleted templates are no longer visible for completion, and completed audits are still accessible.

 