### PR TITLE
add_date_time method and view flag trends refresh button fix

### DIFF
--- a/cilantro_audit/completed_audit_page.py
+++ b/cilantro_audit/completed_audit_page.py
@@ -47,7 +47,7 @@ class CompletedAuditPage(Screen):
         self.grid_list.add_widget(lbl)
 
     # Needs to be updated when you click out of one audit and load up another
-    def add_date_time(self, dt):
+    def add_datetime(self, dt):
         lbl = Label(text='[b]Date: [/b]' + dt, markup=True, size_hint_y=None, height=40, halign="left")
         self.grid_list.add_widget(lbl)
 

--- a/cilantro_audit/completed_audit_page.py
+++ b/cilantro_audit/completed_audit_page.py
@@ -121,8 +121,7 @@ class QuestionAnswer(FloatLayout):
                  auditor=self.resolve_button.auditor,
                  datetime=self.resolve_button.datetime)
         # Remove string label, which has 17 chars as defined in CompletedAuditPage.add_question_answer
-        audit_answer_to_resolve = audit_to_resolve.answers.filter(text=self.question_text[17:]) \
-            .get(text=self.question_text[17:])
+        audit_answer_to_resolve = audit_to_resolve.answers.filter(text=self.question_text[17:]).first()
         audit_answer_to_resolve.resolved = True
         audit_to_resolve.unresolved_count -= 1
         audit_to_resolve.save()

--- a/cilantro_audit/completed_audits_list_page.py
+++ b/cilantro_audit/completed_audits_list_page.py
@@ -273,7 +273,7 @@ class CompletedAuditsListPage(Screen):
         self.manager.get_screen(COMPLETED_AUDIT_PAGE).add_blank_label("")
         self.manager.get_screen(COMPLETED_AUDIT_PAGE).add_title(title)
         self.manager.get_screen(COMPLETED_AUDIT_PAGE).add_auditor(auditor)
-        self.manager.get_screen(COMPLETED_AUDIT_PAGE).add_date_time(format_datetime(utc_to_local(dt)))
+        self.manager.get_screen(COMPLETED_AUDIT_PAGE).add_datetime(format_datetime(utc_to_local(dt)))
 
     def load_audit_template_and_completed_audit_with_title_and_datetime(self, dt):
         ca = list(CompletedAudit.objects(datetime=dt))

--- a/cilantro_audit/completed_audits_list_page.py
+++ b/cilantro_audit/completed_audits_list_page.py
@@ -273,7 +273,7 @@ class CompletedAuditsListPage(Screen):
         self.manager.get_screen(COMPLETED_AUDIT_PAGE).add_blank_label("")
         self.manager.get_screen(COMPLETED_AUDIT_PAGE).add_title(title)
         self.manager.get_screen(COMPLETED_AUDIT_PAGE).add_auditor(auditor)
-        self.manager.get_screen(COMPLETED_AUDIT_PAGE).add_datetime(format_datetime(utc_to_local(dt)))
+        self.manager.get_screen(COMPLETED_AUDIT_PAGE).add_date_time(format_datetime(utc_to_local(dt)))
 
     def load_audit_template_and_completed_audit_with_title_and_datetime(self, dt):
         ca = list(CompletedAudit.objects(datetime=dt))

--- a/cilantro_audit/view_flag_trends_page.py
+++ b/cilantro_audit/view_flag_trends_page.py
@@ -41,8 +41,10 @@ class ViewFlagTrendsPage(Screen):
         self.clear_widgets()
         template_page = CilantroPage()
         template_page.header_title.text = 'Flagged Questions Trend'
+        temp = ViewFlagTrendsPageContent()
         template_page.footer_back.bind(on_release=go_back)
-        template_page.body.add_widget(ViewFlagTrendsPageContent())
+        template_page.footer_refresh.bind(on_release=temp.refresh_flagged_questions)
+        template_page.body.add_widget(temp)
         self.add_widget(template_page)
 
 
@@ -104,7 +106,7 @@ class ViewFlagTrendsPageContent(Screen):
             self.times_flagged_col.add_widget(EntryLabel(text=str(entry_row[2])))
 
     # Refresh the current data by requesting a new data retrieval
-    def refresh_flagged_questions(self):
+    def refresh_flagged_questions(self, instance):
         self.retrieve_flagged_answers()
         self.populate_unique_entry_rows()
 


### PR DESCRIPTION
Master was crashing when a completed audit was loaded due to to naming issues with the add_date_time method in the completed audit page. The refresh button in the view flag trends page was never connected to the refresh method, so I fixed that as well.